### PR TITLE
Make compiler-rt_win-64 installable on windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "compiler-rt-packages" %}
 {% set version = "9.0.1" %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 {% set sha256 = "c2bfab95c9986318318363d7f371a85a95e333bc0b34fbfa52edbd3f5e3a9077" %}
 
 package:
@@ -46,6 +46,7 @@ outputs:
         - libcxx
         - libgcc-ng
         - libstdcxx-ng
+      detect_binary_files_with_prefix: False   # [win]
     requirements:
       build:
         - {{ compiler('cxx') }}


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
