### PR TITLE
Fix path on windows

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,6 +3,10 @@
 mkdir build
 cd build
 
+:: cut off any extensions after "XY.0.0";
+:: mainly aimed at ".rcX", which is not part of the installation path
+set PKG_VERSION=%PKG_VERSION:~0,-4%
+
 set BUILD_CONFIG=Release
 set "CC=clang-cl.exe"
 set "CXX=clang-cl.exe"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -31,5 +31,9 @@ if %ERRORLEVEL% neq 0 exit 1
 cmake --install .
 if %ERRORLEVEL% neq 0 exit 1
 
+:: Also install into %PREFIX%\lib (!= %PREFIX%\Library\lib, the default on win)
+:: because compiler-rt_win-64 is noarch and needs to be installable on linux,
+:: where we don't want the "\Library"; aside from removing that directory,
+:: the paths are the same. Separation into proper outputs happens in the recipe.
 mkdir %PREFIX%\lib\clang\%PKG_VERSION%\lib\windows
 copy %INSTALL_PREFIX%\lib\windows\* %PREFIX%\lib\clang\%PKG_VERSION%\lib\windows\

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - patches/0002-compiler-rt-Make-7.0.0-compatible-with-10.9-SDK.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -51,7 +51,8 @@ outputs:
     test:
       commands:
         - echo {{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}
-        - test -f $PREFIX/lib/clang/{{ prod_ver }}/lib/darwin/libclang_rt.osx.a  # [osx]
+        - test -f $PREFIX/lib/clang/{{ prod_ver }}/lib/darwin/libclang_rt.osx.a                             # [osx]
+        - if not exist %PREFIX%\lib\clang\{{ prod_ver }}\lib\windows\clang_rt.builtins-x86_64.lib exit 1    # [win]
 
   - name: compiler-rt
     requirements:
@@ -65,9 +66,9 @@ outputs:
     files:
       - lib/clang/{{ prod_ver }}/share             # [unix]
       - lib/clang/{{ prod_ver }}/include           # [unix]
-      - Library/lib/clang/{{ version }}/share     # [win]
-      - Library/lib/clang/{{ version }}/include   # [win]
-      - Library/lib/clang/{{ version }}/lib       # [win]
+      - Library\lib\clang\{{ prod_ver }}\share     # [win]
+      - Library\lib\clang\{{ prod_ver }}\include   # [win]
+      - Library\lib\clang\{{ prod_ver }}\lib       # [win]
     test:
       # files:
       #   - test.c.in
@@ -75,7 +76,8 @@ outputs:
         # {% set NEW_TARGET="10." ~ (((MACOSX_DEPLOYMENT_TARGET|default("10.13")).split(".")[1])|int + 1) %}
         # - sed "s/@MACOSX_DEPLOYMENT_TARGET@/{{ NEW_TARGET }}/g" test.c.in > test.c
         # - clang -mmacosx-version-min={{ MACOSX_DEPLOYMENT_TARGET }} test.c  # [osx]
-        - test -f $PREFIX/lib/clang/{{ prod_ver }}/include/sanitizer/asan_interface.h  # [unix]
+        - test -f $PREFIX/lib/clang/{{ prod_ver }}/include/sanitizer/asan_interface.h                       # [unix]
+        - if not exist %LIBRARY_LIB%\clang\{{ prod_ver }}\lib\windows\clang_rt.builtins-x86_64.lib exit 1   # [win]
 
 about:
   home: http://llvm.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,9 @@ outputs:
       run_constrained:
         - compiler-rt {{ version }}
     files:
-      - lib/clang/{{ prod_ver }}/lib
+      - lib/clang/{{ prod_ver }}/lib    # [unix]
+      # avoid "Library\" for noarch output
+      - lib\clang\{{ prod_ver }}\lib    # [win]
     test:
       commands:
         - echo {{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}
@@ -66,6 +68,7 @@ outputs:
     files:
       - lib/clang/{{ prod_ver }}/share             # [unix]
       - lib/clang/{{ prod_ver }}/include           # [unix]
+      # standard windows layout for arch-specific output
       - Library\lib\clang\{{ prod_ver }}\share     # [win]
       - Library\lib\clang\{{ prod_ver }}\include   # [win]
       - Library\lib\clang\{{ prod_ver }}\lib       # [win]


### PR DESCRIPTION
~Figure out a stray suffix on the expected path to the windows builtins.~

Fix path for rc's also on windows; unix does this already for a long time:
https://github.com/conda-forge/compiler-rt-feedstock/blob/303aa8789b28f27644191c5665f750317a71926b/recipe/build.sh#L33-L35

~Also pick up a pending cleanup now that https://github.com/conda/conda-build/issues/4787 got fixed by the newest conda-build.~ Not ready yet, see https://github.com/conda-forge/boa-feedstock/issues/75