### PR TITLE
[16.x] add test for resource_dir on windows

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,4 +1,5 @@
 @echo on
+setlocal enabledelayedexpansion
 
 mkdir build
 cd build
@@ -31,6 +32,14 @@ if %ERRORLEVEL% neq 0 exit 1
 :: Install step
 cmake --install .
 if %ERRORLEVEL% neq 0 exit 1
+
+FOR /F "tokens=* USEBACKQ" %%F IN (`clang -print-resource-dir`) DO (
+    set "RESOURCE_DIR=%%F"
+)
+if "!RESOURCE_DIR!" NEQ "%INSTALL_PREFIX%" (
+    echo "Wrong install prefix (%INSTALL_PREFIX%). Should match !RESOURCE_DIR!"
+    exit 1
+)
 
 :: Also install into %PREFIX%\lib (!= %PREFIX%\Library\lib, the default on win)
 :: because compiler-rt_win-64 is noarch and needs to be installable on linux,

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -32,5 +32,9 @@ if %ERRORLEVEL% neq 0 exit 1
 cmake --install .
 if %ERRORLEVEL% neq 0 exit 1
 
+:: Also install into %PREFIX%\lib (!= %PREFIX%\Library\lib, the default on win)
+:: because compiler-rt_win-64 is noarch and needs to be installable on linux,
+:: where we don't want the "\Library"; aside from removing that directory,
+:: the paths are the same. Separation into proper outputs happens in the recipe.
 mkdir %PREFIX%\lib\clang\%MAJOR_VER%\lib\windows
 copy %INSTALL_PREFIX%\lib\windows\* %PREFIX%\lib\clang\%MAJOR_VER%\lib\windows\

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -36,5 +36,6 @@ if %ERRORLEVEL% neq 0 exit 1
 :: because compiler-rt_win-64 is noarch and needs to be installable on linux,
 :: where we don't want the "\Library"; aside from removing that directory,
 :: the paths are the same. Separation into proper outputs happens in the recipe.
-mkdir %PREFIX%\lib\clang\%MAJOR_VER%\lib\windows
-copy %INSTALL_PREFIX%\lib\windows\* %PREFIX%\lib\clang\%MAJOR_VER%\lib\windows\
+set "INSTALL_PREFIX_NOARCH=%PREFIX%\lib\clang\%MAJOR_VER%"
+mkdir %INSTALL_PREFIX_NOARCH%\lib\windows
+copy %INSTALL_PREFIX%\lib\windows\* %INSTALL_PREFIX_NOARCH%\lib\windows\

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,9 @@ outputs:
       run_constrained:
         - compiler-rt {{ version }}
     files:
-      - lib/clang/{{ major_ver }}/lib
+      - lib/clang/{{ major_ver }}/lib   # [unix]
+      # avoid "Library\" for noarch output
+      - lib\clang\{{ major_ver }}\lib   # [win]
     test:
       commands:
         - echo {{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}
@@ -64,6 +66,7 @@ outputs:
     files:
       - lib/clang/{{ major_ver }}/share             # [unix]
       - lib/clang/{{ major_ver }}/include           # [unix]
+      # standard windows layout for arch-specific output
       - Library/lib/clang/{{ major_ver }}/share     # [win]
       - Library/lib/clang/{{ major_ver }}/include   # [win]
       - Library/lib/clang/{{ major_ver }}/lib       # [win]


### PR DESCRIPTION
Follow-up to #89; backport from #90 (and e94a48de1fb232089d8bebc278fa1ae4e7b67f0f, while we're at it)