### PR TITLE
[dev] compiler-rt 19.0.0.dev0

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -5,9 +5,9 @@ c_stdlib_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge
+- conda-forge/label/llvm_dev,conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge llvm_dev
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -22,4 +22,4 @@ zip_keys:
 - - c_stdlib_version
   - cdt_name
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -9,9 +9,9 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge
+- conda-forge/label/llvm_dev,conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge llvm_dev
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -26,4 +26,4 @@ zip_keys:
 - - c_stdlib_version
   - cdt_name
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -5,9 +5,9 @@ c_stdlib_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge
+- conda-forge/label/llvm_dev,conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge llvm_dev
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -22,4 +22,4 @@ zip_keys:
 - - c_stdlib_version
   - cdt_name
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -7,9 +7,9 @@ c_stdlib:
 c_stdlib_version:
 - '10.13'
 channel_sources:
-- conda-forge
+- conda-forge/label/llvm_dev,conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge llvm_dev
 cxx_compiler:
 - clang_bootstrap
 cxx_compiler_version:
@@ -21,4 +21,4 @@ macos_machine:
 target_platform:
 - osx-64
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -7,9 +7,9 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge
+- conda-forge/label/llvm_dev,conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge llvm_dev
 cxx_compiler:
 - clang_bootstrap
 cxx_compiler_version:
@@ -21,4 +21,4 @@ macos_machine:
 target_platform:
 - osx-arm64
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,9 +1,9 @@
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge
+- conda-forge/label/llvm_dev,conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge llvm_dev
 cxx_compiler:
 - vs2019
 libxml2:
@@ -11,4 +11,4 @@ libxml2:
 target_platform:
 - win-64
 zlib:
-- '1.2'
+- '1'

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -69,6 +69,13 @@ else
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
+
+    ( startgroup "Inspecting artifacts" ) 2> /dev/null
+
+    # inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
+    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+
+    ( endgroup "Inspecting artifacts" ) 2> /dev/null
     ( startgroup "Validating outputs" ) 2> /dev/null
 
     validate_recipe_outputs "${FEEDSTOCK_NAME}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -81,6 +81,13 @@ else
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
         --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"
+
+    ( startgroup "Inspecting artifacts" ) 2> /dev/null
+
+    # inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
+    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+
+    ( endgroup "Inspecting artifacts" ) 2> /dev/null
     ( startgroup "Validating outputs" ) 2> /dev/null
 
     validate_recipe_outputs "${FEEDSTOCK_NAME}"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -53,6 +53,11 @@ echo Building recipe
 conda-build.exe "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
 if !errorlevel! neq 0 exit /b !errorlevel!
 
+call :start_group "Inspecting artifacts"
+:: inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
+WHERE inspect_artifacts >nul 2>nul && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+call :end_group
+
 :: Prepare some environment variables for the upload step
 if /i "%CI%" == "github_actions" (
     set "FEEDSTOCK_NAME=%GITHUB_REPOSITORY:*/=%"

--- a/README.md
+++ b/README.md
@@ -98,14 +98,14 @@ Current release info
 Installing compiler-rt
 ======================
 
-Installing `compiler-rt` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `compiler-rt` from the `conda-forge/label/llvm_dev` channel can be achieved by adding `conda-forge/label/llvm_dev` to your channels with:
 
 ```
-conda config --add channels conda-forge
+conda config --add channels conda-forge/label/llvm_dev
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `compiler-rt, compiler-rt_linux-64` can be installed with `conda`:
+Once the `conda-forge/label/llvm_dev` channel has been enabled, `compiler-rt, compiler-rt_linux-64` can be installed with `conda`:
 
 ```
 conda install compiler-rt compiler-rt_linux-64
@@ -120,26 +120,26 @@ mamba install compiler-rt compiler-rt_linux-64
 It is possible to list all of the versions of `compiler-rt` available on your platform with `conda`:
 
 ```
-conda search compiler-rt --channel conda-forge
+conda search compiler-rt --channel conda-forge/label/llvm_dev
 ```
 
 or with `mamba`:
 
 ```
-mamba search compiler-rt --channel conda-forge
+mamba search compiler-rt --channel conda-forge/label/llvm_dev
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search compiler-rt --channel conda-forge
+mamba repoquery search compiler-rt --channel conda-forge/label/llvm_dev
 
 # List packages depending on `compiler-rt`:
-mamba repoquery whoneeds compiler-rt --channel conda-forge
+mamba repoquery whoneeds compiler-rt --channel conda-forge/label/llvm_dev
 
 # List dependencies of `compiler-rt`:
-mamba repoquery depends compiler-rt --channel conda-forge
+mamba repoquery depends compiler-rt --channel conda-forge/label/llvm_dev
 ```
 
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,3 +4,8 @@ c_compiler:          # [osx]
   - clang_bootstrap  # [osx]
 cxx_compiler:        # [osx]
   - clang_bootstrap  # [osx]
+
+channel_targets:
+  - conda-forge llvm_dev
+channel_sources:
+  - conda-forge/label/llvm_dev,conda-forge

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "18.1.7" %}
+{% set version = "19.0.0.dev0" %}
 {% set major_ver = version.split('.')[0] %}
 
 package:
@@ -6,8 +6,10 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
-  sha256: b60df7cbe02cef2523f7357120fb0d46cbb443791cde3a5fb36b82c335c0afc9
+  git_url: https://github.com/llvm/llvm-project.git
+  git_rev: 1754651dd150139d64cdae190afe1faabf69a403
+  # url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
+  # sha256: b60df7cbe02cef2523f7357120fb0d46cbb443791cde3a5fb36b82c335c0afc9
   patches:
     - patches/0001-no-code-sign.patch
 

--- a/recipe/patches/0001-no-code-sign.patch
+++ b/recipe/patches/0001-no-code-sign.patch
@@ -1,47 +1,50 @@
-From bf3c5b20918704c6f07f5aecef840376fd3b0806 Mon Sep 17 00:00:00 2001
+From df12de3c3a271638a55950feb9c57c7f95b8509b Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Mon, 22 Apr 2019 02:00:30 -0500
 Subject: [PATCH] no code sign
 
 ---
- compiler-rt/cmake/Modules/AddCompilerRT.cmake | 28 -------------------
- 1 file changed, 28 deletions(-)
+ compiler-rt/cmake/Modules/AddCompilerRT.cmake | 31 -------------------
+ 1 file changed, 31 deletions(-)
 
 diff --git a/compiler-rt/cmake/Modules/AddCompilerRT.cmake b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
-index e0400a8ea952..ee51eb5bc514 100644
+index 298093462f80..52dc54979056 100644
 --- a/compiler-rt/cmake/Modules/AddCompilerRT.cmake
 +++ b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
-@@ -392,34 +392,6 @@ function(add_compiler_rt_runtime name type)
+@@ -387,37 +387,6 @@ function(add_compiler_rt_runtime name type)
          set_target_properties(${libname} PROPERTIES IMPORT_PREFIX "")
          set_target_properties(${libname} PROPERTIES IMPORT_SUFFIX ".lib")
        endif()
 -      if (APPLE AND NOT CMAKE_LINKER MATCHES ".*lld.*")
--        # Ad-hoc sign the dylibs when using Xcode versions older than 12.
--        # Xcode 12 shipped with ld64-609.
--        # FIXME: Remove whole conditional block once everything uses Xcode 12+.
--        set(LD_V_OUTPUT)
+-        # Apple's linker signs the resulting dylib with an ad-hoc code signature in
+-        # most situations, except:
+-        # 1. Versions of ld64 prior to ld64-609 in Xcode 12 predate this behavior.
+-        # 2. Apple's new linker does not when building with `-darwin-target-variant`
+-        #    to support macOS Catalyst.
+-        #
+-        # Explicitly re-signing the dylib works around both of these issues. The
+-        # signature is marked as `linker-signed` when that is supported so that it
+-        # behaves as expected when processed by subsequent tooling.
+-        #
+-        # Detect whether `codesign` supports `-o linker-signed` by passing it as an
+-        # argument and looking for `invalid argument "linker-signed"` in its output.
+-        # FIXME: Remove this once all supported toolchains support `-o linker-signed`.
 -        execute_process(
--          COMMAND sh -c "${CMAKE_LINKER} -v 2>&1 | head -1"
--          RESULT_VARIABLE HAD_ERROR
--          OUTPUT_VARIABLE LD_V_OUTPUT
+-          COMMAND sh -c "codesign -f -s - -o linker-signed this-does-not-exist 2>&1 | grep -q linker-signed"
+-          RESULT_VARIABLE CODESIGN_SUPPORTS_LINKER_SIGNED
 -        )
--        if (HAD_ERROR)
--          message(FATAL_ERROR "${CMAKE_LINKER} failed with status ${HAD_ERROR}")
+-
+-        set(EXTRA_CODESIGN_ARGUMENTS)
+-        if (CODESIGN_SUPPORTS_LINKER_SIGNED)
+-          list(APPEND EXTRA_CODESIGN_ARGUMENTS -o linker-signed)
 -        endif()
--        set(NEED_EXPLICIT_ADHOC_CODESIGN 1)
--        if ("${LD_V_OUTPUT}" MATCHES ".*ld64-([0-9.]+).*")
--          string(REGEX REPLACE ".*ld64-([0-9.]+).*" "\\1" HOST_LINK_VERSION ${LD_V_OUTPUT})
--          if (HOST_LINK_VERSION VERSION_GREATER_EQUAL 609)
--            set(NEED_EXPLICIT_ADHOC_CODESIGN 0)
--          endif()
--        endif()
--        if (NEED_EXPLICIT_ADHOC_CODESIGN)
--          add_custom_command(TARGET ${libname}
--            POST_BUILD
--            COMMAND codesign --sign - $<TARGET_FILE:${libname}>
--            WORKING_DIRECTORY ${COMPILER_RT_OUTPUT_LIBRARY_DIR}
--          )
--        endif()
+-
+-        add_custom_command(TARGET ${libname}
+-          POST_BUILD
+-          COMMAND codesign --sign - ${EXTRA_CODESIGN_ARGUMENTS} $<TARGET_FILE:${libname}>
+-          WORKING_DIRECTORY ${COMPILER_RT_OUTPUT_LIBRARY_DIR}
+-          COMMAND_EXPAND_LISTS
+-        )
 -      endif()
      endif()
  


### PR DESCRIPTION
Match `dev` branch with llvmdev feedstock; build a consistent stack from LLVM main, in order to test newer flang.