### PR TITLE
[rc] lighten run-dependencies; clangxx not obligatory

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patches/0001-no-code-sign.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -44,8 +44,8 @@ outputs:
       host:
       run:
         - clang {{ version }}
-        - clangxx {{ version }}
       run_constrained:
+        - clangxx {{ version }}
         - compiler-rt {{ version }}
     files:
       - lib/clang/{{ major_ver }}/lib   # [unix]
@@ -65,7 +65,6 @@ outputs:
       host:
       run:
         - clang {{ version }}
-        - clangxx {{ version }}
         - compiler-rt_{{ target_platform }} {{ version }}
     files:
       - lib/clang/{{ major_ver }}/share             # [unix]


### PR DESCRIPTION
There are legitimate uses of compiler-rt without a C++ compiler (e.g. for flang); remove the run-dependence on clangxx.