### PR TITLE
compiler-rt v19.1.0.rc4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "19.1.0.rc3" %}
+{% set version = "19.1.0.rc4" %}
 {% set major_ver = version.split('.')[0] %}
 
 package:
@@ -7,13 +7,13 @@ package:
 
 source:
   url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
-  sha256: 57f926edf60a92947fa9b8b0adfdf3c6f2182a4ecf1c929176218eef619d7411
+  sha256: 570ea538eae9939e1b008c4e8055227dae3ab58054c74707ad1d5a8cb51536c3
   patches:
     - patches/0001-no-code-sign.patch
     - patches/0002-Revert-Declare-_availability_version_check-as-weak_i.patch
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,10 @@ source:
   sha256: 57f926edf60a92947fa9b8b0adfdf3c6f2182a4ecf1c929176218eef619d7411
   patches:
     - patches/0001-no-code-sign.patch
+    - patches/0002-Revert-Declare-_availability_version_check-as-weak_i.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/patches/0001-no-code-sign.patch
+++ b/recipe/patches/0001-no-code-sign.patch
@@ -1,7 +1,7 @@
-From 3a686bf47180a54862a935069849015303af2329 Mon Sep 17 00:00:00 2001
+From 3f0b22d7746015db51f0fc59068683e6c459d45a Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Mon, 22 Apr 2019 02:00:30 -0500
-Subject: [PATCH] no code sign
+Subject: [PATCH 1/2] no code sign
 
 ---
  compiler-rt/cmake/Modules/AddCompilerRT.cmake | 31 -------------------

--- a/recipe/patches/0002-Revert-Declare-_availability_version_check-as-weak_i.patch
+++ b/recipe/patches/0002-Revert-Declare-_availability_version_check-as-weak_i.patch
@@ -1,0 +1,37 @@
+From 3752b27ad235cd1126f72929d982bbecb27985ad Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Mon, 2 Sep 2024 14:30:13 +1100
+Subject: [PATCH 2/2] Revert "Declare _availability_version_check as
+ weak_import instead of looking it"
+
+This reverts commit b653a2823fe4b4c9c6d85cfe119f31d8e70c2fa0.
+---
+ compiler-rt/lib/builtins/os_version_check.c | 8 ++------
+ 1 file changed, 2 insertions(+), 6 deletions(-)
+
+diff --git a/compiler-rt/lib/builtins/os_version_check.c b/compiler-rt/lib/builtins/os_version_check.c
+index 01fae834ab21..5febb79c0749 100644
+--- a/compiler-rt/lib/builtins/os_version_check.c
++++ b/compiler-rt/lib/builtins/os_version_check.c
+@@ -86,10 +86,6 @@ typedef Boolean (*CFStringGetCStringFuncTy)(CFStringRef, char *, CFIndex,
+                                             CFStringEncoding);
+ typedef void (*CFReleaseFuncTy)(CFTypeRef);
+ 
+-extern __attribute__((weak_import))
+-bool _availability_version_check(uint32_t count,
+-                                 dyld_build_version_t versions[]);
+-
+ static void _initializeAvailabilityCheck(bool LoadPlist) {
+   if (AvailabilityVersionCheck && !LoadPlist) {
+     // New API is supported and we're not being asked to load the plist,
+@@ -98,8 +94,8 @@ static void _initializeAvailabilityCheck(bool LoadPlist) {
+   }
+ 
+   // Use the new API if it's is available.
+-  if (_availability_version_check)
+-    AvailabilityVersionCheck = &_availability_version_check;
++  AvailabilityVersionCheck = (AvailabilityVersionCheckFuncTy)dlsym(
++      RTLD_DEFAULT, "_availability_version_check");
+ 
+   if (AvailabilityVersionCheck && !LoadPlist) {
+     // New API is supported and we're not being asked to load the plist,


### PR DESCRIPTION
https://github.com/conda-forge/clang-compiler-activation-feedstock/issues/139 still affects clang 19; tested in https://github.com/conda-forge/sdl2-feedstock/pull/55