### PR TITLE
[dev] add lld on windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - patches/0002-Revert-Declare-_availability_version_check-as-weak_i.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -23,6 +23,7 @@ requirements:
     - {{ stdlib('c') }}
     - python *
     - ninja
+    - lld                    # [win]
     - llvmdev {{ version }}  # [build_platform != target_platform]
   host:
     - clangdev {{ version }}


### PR DESCRIPTION
So this is very weird - CI for #137 passed after merging main, but the package is not downloadable due to https://github.com/conda/infrastructure/issues/1141. So I pushed f21990a1e16578c9ddc3f8b98d36e7d080490959, and now the build fails with

```
-- Check for working C compiler: D:/bld/compiler-rt-packages_1743126973855/_h_env/Library/bin/clang-cl.exe - broken
  The C compiler

    "D:/bld/compiler-rt-packages_1743126973855/_h_env/Library/bin/clang-cl.exe"

-- Configuring incomplete, errors occurred!
  is not able to compile a simple test program.

  It fails with the following output:

    Change Dir: 'D:/bld/compiler-rt-packages_1743126973855/work/build/CMakeFiles/CMakeScratch/TryCompile-lw1jj3'
    

    Run Build Command(s): D:/bld/compiler-rt-packages_1743126973855/_build_env/Library/bin/ninja.exe -v cmTC_9a5f3
(base) %SRC_DIR%\build>if 1 NEQ 0 exit 1 
    [1/2] D:\bld\compiler-rt-packages_1743126973855\_h_env\Library\bin\clang-cl.exe  /nologo   /DWIN32 /D_WINDOWS  /Ob0 /Od /RTC1 -MDd -Zi /showIncludes /FoCMakeFiles\cmTC_9a5f3.dir\testCCompiler.c.obj /FdCMakeFiles\cmTC_9a5f3.dir\ -c -- D:\bld\compiler-rt-packages_1743126973855\work\build\CMakeFiles\CMakeScratch\TryCompile-lw1jj3\testCCompiler.c
    [2/2] C:\Windows\system32\cmd.exe /C "cd . && D:\bld\compiler-rt-packages_1743126973855\_build_env\Library\bin\cmake.exe -E vs_link_exe --msvc-ver=1943 --intdir=CMakeFiles\cmTC_9a5f3.dir --rc=D:\bld\compiler-rt-packages_1743126973855\_h_env\Library\bin\llvm-rc.exe --mt=D:\bld\compiler-rt-packages_1743126973855\_h_env\Library\bin\llvm-mt.exe --manifests  -- C:\PROGRA~1\LLVM\bin\lld-link.exe /nologo CMakeFiles\cmTC_9a5f3.dir\testCCompiler.c.obj  /out:cmTC_9a5f3.exe /implib:cmTC_9a5f3.lib /pdb:cmTC_9a5f3.pdb /version:0.0 /machine:x64  /debug /INCREMENTAL /subsystem:console  kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib && cd ."
    FAILED: cmTC_9a5f3.exe 
    C:\Windows\system32\cmd.exe /C "cd . && D:\bld\compiler-rt-packages_1743126973855\_build_env\Library\bin\cmake.exe -E vs_link_exe --msvc-ver=1943 --intdir=CMakeFiles\cmTC_9a5f3.dir --rc=D:\bld\compiler-rt-packages_1743126973855\_h_env\Library\bin\llvm-rc.exe --mt=D:\bld\compiler-rt-packages_1743126973855\_h_env\Library\bin\llvm-mt.exe --manifests  -- C:\PROGRA~1\LLVM\bin\lld-link.exe /nologo CMakeFiles\cmTC_9a5f3.dir\testCCompiler.c.obj  /out:cmTC_9a5f3.exe /implib:cmTC_9a5f3.lib /pdb:cmTC_9a5f3.pdb /version:0.0 /machine:x64  /debug /INCREMENTAL /subsystem:console  kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib && cd ."
    LINK Pass 1: command "C:\PROGRA~1\LLVM\bin\lld-link.exe /nologo CMakeFiles\cmTC_9a5f3.dir\testCCompiler.c.obj /out:cmTC_9a5f3.exe /implib:cmTC_9a5f3.lib /pdb:cmTC_9a5f3.pdb /version:0.0 /machine:x64 /debug /INCREMENTAL /subsystem:console kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST /MANIFESTFILE:CMakeFiles\cmTC_9a5f3.dir/intermediate.manifest CMakeFiles\cmTC_9a5f3.dir/manifest.res" failed (exit code 1) with the following output:
    lld-link: error: could not open 'kernel32.lib': no such file or directory
    lld-link: error: could not open 'user32.lib': no such file or directory
    lld-link: error: could not open 'gdi32.lib': no such file or directory
    lld-link: error: could not open 'winspool.lib': no such file or directory
    lld-link: error: could not open 'shell32.lib': no such file or directory
    lld-link: error: could not open 'ole32.lib': no such file or directory
    lld-link: error: could not open 'oleaut32.lib': no such file or directory
    lld-link: error: could not open 'uuid.lib': no such file or directory
    lld-link: error: could not open 'comdlg32.lib': no such file or directory
    lld-link: error: could not open 'advapi32.lib': no such file or directory
    lld-link: error: could not open 'msvcrtd.lib': no such file or directory
    lld-link: error: could not open 'oldnames.lib': no such file or directory
  ```

More interestingly, lld is not specified anywhere in the recipe, so I don't even know what was happening here previously.