### PR TITLE
[20.x] Rebuild for libxml2 2.14

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-13
+    vmImage: macOS-15
   strategy:
     matrix:
       osx_64_:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -14,8 +14,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-libxml2:
-- '2.13'
+libxml2_devel:
+- '2.14'
 target_platform:
 - linux-64
 zlib:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -14,8 +14,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-libxml2:
-- '2.13'
+libxml2_devel:
+- '2.14'
 target_platform:
 - linux-aarch64
 zlib:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -14,8 +14,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-libxml2:
-- '2.13'
+libxml2_devel:
+- '2.14'
 target_platform:
 - linux-ppc64le
 zlib:

--- a/.ci_support/migrations/libxml2214.yaml
+++ b/.ci_support/migrations/libxml2214.yaml
@@ -1,0 +1,10 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for libxml2 2.14
+  kind: version
+  migration_number: 1
+libxml2:
+- '2.14'
+libxml2_devel:
+- '2.14'
+migrator_ts: 1743812129.3751788

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -14,8 +14,8 @@ cxx_compiler:
 - clang_bootstrap
 cxx_compiler_version:
 - '19'
-libxml2:
-- '2.13'
+libxml2_devel:
+- '2.14'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -14,8 +14,8 @@ cxx_compiler:
 - clang_bootstrap
 cxx_compiler_version:
 - '19'
-libxml2:
-- '2.13'
+libxml2_devel:
+- '2.14'
 macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -6,8 +6,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2022
-libxml2:
-- '2.13'
+libxml2_devel:
+- '2.14'
 target_platform:
 - win-64
 zlib:

--- a/.gitattributes
+++ b/.gitattributes
@@ -24,4 +24,5 @@ bld.bat text eol=crlf
 /README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true
 build-locally.py linguist-generated=true
+pixi.toml linguist-generated=true
 shippable.yml linguist-generated=true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - patches/0002-Revert-Declare-_availability_version_check-as-weak_i.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -28,7 +28,7 @@ requirements:
     - llvmdev {{ version }}
     - libcxx   # [osx]
     - zlib
-    - libxml2
+    - libxml2-devel
 
 outputs:
   - name: compiler-rt_{{ target_platform }}


### PR DESCRIPTION
Bot seems to be waiting for phantom parents due to circular dependencies between xml2 and the compiler stack