### PR TITLE
break bootstrap cycle for win-arm64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - patches/0002-Revert-Declare-_availability_version_check-as-weak_i.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -22,8 +22,11 @@ requirements:
     - {{ stdlib('c') }}
     - python *
     - ninja
-    - llvmdev {{ version }}  # [build_platform != target_platform]
-    - clang                  # [win]
+    - llvmdev {{ version }}     # [unix and build_platform != target_platform]
+    # win-arm64 needs clang to build, which requires compiler-rt; to break the cycle,
+    # allow older patch versions of llvmdev, for which we already have matching clang
+    - llvmdev {{ major_ver }}   # [win and build_platform != target_platform]
+    - clang                     # [win]
   host:
     - llvmdev {{ version }}
     - libcxx   # [osx]


### PR DESCRIPTION
From #174:
> This [cb24eda5d632cec9d6c226cdec5c13cf65584200] unfortunately introduces a bootstrapping cycle. `clang` depends on `compiler-rt` nowadays, so it gets built afterwards; but to have `clang` next to `llvmdev` means that the versions have to match. This is not the end of the world (we can still merge here, and then retrigger once clang for `win-64` has been built), but it's annoying. 😑
> 
> The alternative would be to loosen the version constraint on `llvmdev` here so that `X.Y.{Z-1}` is also acceptable. That would technically be incorrect, but it'd only apply to win-arm64, and it's quite unlikely (for patch versions) that major changes happen in llvmdev that would then break its internal consumers.

This will not solve the situation for new major version (where we'd still have to build `compiler-rt [win-64]` -> `clang [win-64]` -> `compiler-rt [win-arm64]` -> `clang [win-arm64]`), but at least that would only happen twice per year.